### PR TITLE
Fix demo1's create_ec2.py

### DIFF
--- a/demo1/create_ec2.py
+++ b/demo1/create_ec2.py
@@ -49,7 +49,7 @@ HARD_DISKS = [
             'VolumeType': 'gp2'
         },
     },
-],
+]
 
 client = boto3.client('ec2', region_name='us-east-1')
 


### PR DESCRIPTION
When refactoring to make code fit on slides, the HARD_DISKS section was
broken out into its own area. However, a stray comma had changed the
type actually breaking the demo.